### PR TITLE
[Fix] After removing one task, the search term still be used to filter but it disappears from the screen #35

### DIFF
--- a/examples/todo/imports/ui/Tasks.js
+++ b/examples/todo/imports/ui/Tasks.js
@@ -60,6 +60,7 @@ class TasksComponent extends React.Component {
             fullWidth
             name="search"
             onChange={this.onInputChange}
+            value={this.state.search}
           />
           <Button
             className="form-action"


### PR DESCRIPTION
After removing one task, the search term still be used to filter but it disappears from the screen #35